### PR TITLE
Fix up typo - replace adddres with address.

### DIFF
--- a/src/urllib3/packages/rfc3986/uri.py
+++ b/src/urllib3/packages/rfc3986/uri.py
@@ -73,7 +73,7 @@ class URIReference(namedtuple("URIReference", misc.URI_COMPONENTS), URIMixin):
 
     .. attribute:: host
 
-        The hostname, IPv4, or IPv6 adddres parsed from the authority.
+        The hostname, IPv4, or IPv6 address parsed from the authority.
 
     .. attribute:: port
 

--- a/test/test_compatibility.py
+++ b/test/test_compatibility.py
@@ -25,7 +25,7 @@ class TestVersionCompatibility(object):
             # source_address does not exist in Py26-
             HTTPConnection("localhost", 12345, source_address="127.0.0.1")
         except TypeError as e:
-            pytest.fail("HTTPConnection raised TypeError on source_adddress: %r" % e)
+            pytest.fail("HTTPConnection raised TypeError on source_address: %r" % e)
 
 
 class TestCookiejar(object):


### PR DESCRIPTION
Fix up typo - replace adddres with address.